### PR TITLE
初版道具系统及玩家抽象类模板

### DIFF
--- a/Assets/Resources/ItemDataTable.asset
+++ b/Assets/Resources/ItemDataTable.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ffe8f849ec4ad0c439c8d73df633af24, type: 3}
+  m_Name: ItemDataTable
+  m_EditorClassIdentifier: 
+  PowerList: []

--- a/Assets/Resources/ItemDataTable.asset.meta
+++ b/Assets/Resources/ItemDataTable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ff5a5bde011c0de49acd5fbda61ca428
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefabs/ItemPrefab.prefab
+++ b/Assets/Resources/Prefabs/ItemPrefab.prefab
@@ -1,0 +1,120 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2633313612155404844
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4830481515559956736}
+  - component: {fileID: 204462590923306160}
+  - component: {fileID: 1116116255098921828}
+  - component: {fileID: 8526735411571802513}
+  - component: {fileID: 9166614874193091830}
+  m_Layer: 0
+  m_Name: ItemPrefab
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4830481515559956736
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2633313612155404844}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &204462590923306160
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2633313612155404844}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1116116255098921828
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2633313612155404844}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &8526735411571802513
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2633313612155404844}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &9166614874193091830
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2633313612155404844}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 77bc9c8757bcaa0448229caacd927c31, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Resources/Prefabs/ItemPrefab.prefab.meta
+++ b/Assets/Resources/Prefabs/ItemPrefab.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 773449e97ec69e146800a8dbe4f4c506
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Event/PlayerGetItem.cs
+++ b/Assets/Script/Event/PlayerGetItem.cs
@@ -1,0 +1,4 @@
+public class PlayerGetItem
+{
+    public IPlayer player;
+}

--- a/Assets/Script/Event/PlayerGetItem.cs.meta
+++ b/Assets/Script/Event/PlayerGetItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e249034e2b21364d8cf0629c8c70dfe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/GameManager.cs
+++ b/Assets/Script/Game/GameManager.cs
@@ -1,18 +1,16 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class GameManager : Singleton<GameManager>
 {
     public RenderTexture mapMaskTexture;
     public Paintable mapPaintable;
-
-
+    private ItemSystem itemSystem;
     protected override void Awake()
     {
         base.Awake();
         //各システムの実例化と初期化
-
+        itemSystem=ItemSystem.Instance;
+        itemSystem.Init();
     }
 
     private void Update()

--- a/Assets/Script/System/EventSystemSample/EventSystemTest.cs
+++ b/Assets/Script/System/EventSystemSample/EventSystemTest.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 public class EventSystemTest : MonoBehaviour
 {
@@ -6,15 +7,15 @@ public class EventSystemTest : MonoBehaviour
     void Start()
     {
         //需要从事件中获得数据的写法
-        TypeEventSystem.Instance.Register<KillEvent>(e => {
-            Debug.Log(e.Name+e.Age);
-            kill();
-        }).UnregisterWhenGameObjectDestroyde(gameObject);
-        //只需要响应事件的写法
         TypeEventSystem.Instance.Register<KillEvent>(e =>
         {
-            kill();
+            Debug.Log(e.Name + " " + e.Age);
         }).UnregisterWhenGameObjectDestroyde(gameObject);
+        //只需要响应事件的写法
+        //TypeEventSystem.Instance.Register<GameStartEvent>(e =>
+        //{
+        //    kill();
+        //});
     }
 
     void kill()
@@ -26,15 +27,18 @@ public class EventSystemTest : MonoBehaviour
     {
         if(Input.GetMouseButtonDown(0))
         {
+            KillEvent killEvent = new KillEvent();
+            killEvent.Name = "steven";
+            killEvent.Age = 18;
             //传递数据的写法
-            TypeEventSystem.Instance.Send<KillEvent>(new KillEvent()
+            TypeEventSystem.Instance.Send<KillEvent>(new KillEvent
             {
-                Name = "Steven",
-                Age=18
+                Name = "steven",
+                Age = 18
             });
-
+            
             //只发送事件的写法
-            TypeEventSystem.Instance.Send<KillEvent>();
+            //TypeEventSystem.Instance.Send<GameStartEvent>();
         }
     }
 }

--- a/Assets/Script/System/EventSystemSample/GameStartEvent.cs
+++ b/Assets/Script/System/EventSystemSample/GameStartEvent.cs
@@ -1,0 +1,4 @@
+public class GameStartEvent
+{
+
+}

--- a/Assets/Script/System/EventSystemSample/GameStartEvent.cs.meta
+++ b/Assets/Script/System/EventSystemSample/GameStartEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36a359de760c48746b38c13d5bb82ee0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/System/ItemSystem.meta
+++ b/Assets/Script/System/ItemSystem.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2636ad540927dbe42b5f5ec6b38ca533
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/System/ItemSystem/IItem.cs
+++ b/Assets/Script/System/ItemSystem/IItem.cs
@@ -1,0 +1,9 @@
+public interface IItem
+{
+    public void Action(TPlayer player);
+}
+
+public abstract class Item :IItem 
+{
+    public abstract void Action(TPlayer player);
+}

--- a/Assets/Script/System/ItemSystem/IItem.cs.meta
+++ b/Assets/Script/System/ItemSystem/IItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97d28fcac40fc6e45ac3d83fa64c72c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/System/ItemSystem/IPlayer.cs
+++ b/Assets/Script/System/ItemSystem/IPlayer.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+public interface IPlayer
+{
+    public void UseItem(TPlayer player);
+    public void GetItem(IItem item);
+    public bool isHadSilk { get; }
+    public bool isHadItem { get; }
+}
+public abstract class TPlayer :MonoBehaviour, IPlayer
+{
+    public bool isHadSilk => false;
+
+    public bool isHadItem => item != null;
+
+    //“¹‹ï
+    IItem item;
+    //Ž…todo...
+
+    public void GetItem(IItem item)
+    {
+        this.item = item;
+    }
+
+    public void UseItem(TPlayer player)
+    {
+        if(item != null)
+        {
+            item.Action(player);
+            item=null;
+        }
+    }
+}

--- a/Assets/Script/System/ItemSystem/IPlayer.cs.meta
+++ b/Assets/Script/System/ItemSystem/IPlayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2724a14ebf74d54390be0f9f65d5c64
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/System/ItemSystem/ItemData.cs
+++ b/Assets/Script/System/ItemSystem/ItemData.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName ="ItemDataTable",menuName = "ItemSystem/ItemDataTable")]
+public class ItemData : ScriptableObject
+{
+    [SerializeField]
+    public List<Item> PowerList = new List<Item>();
+    [SerializeField]
+    public List<Item> NormalList = new List<Item>();
+}

--- a/Assets/Script/System/ItemSystem/ItemData.cs.meta
+++ b/Assets/Script/System/ItemSystem/ItemData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ffe8f849ec4ad0c439c8d73df633af24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/System/ItemSystem/ItemObject.cs
+++ b/Assets/Script/System/ItemSystem/ItemObject.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+public class ItemObject : MonoBehaviour
+{
+    private void OnCollisionEnter(Collision other)
+    {
+        if (other.transform.gameObject.GetComponent<TPlayer>())
+        {
+            TypeEventSystem.Instance.Send<PlayerGetItem>(new PlayerGetItem()
+            {
+                player = other.gameObject.GetComponent<IPlayer>()
+            });
+        }
+    }
+}

--- a/Assets/Script/System/ItemSystem/ItemObject.cs.meta
+++ b/Assets/Script/System/ItemSystem/ItemObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77bc9c8757bcaa0448229caacd927c31
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/System/ItemSystem/ItemSystem.cs
+++ b/Assets/Script/System/ItemSystem/ItemSystem.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+public class ItemSystem : SingletonBase<ItemSystem>
+{
+    GameObject itemPrefab;
+    GameObject itemObj;
+    //糸持ってないやつ獲得できる
+    List<Item> attackItemList = new List<Item>();
+    //持っているやつ
+    List<Item> dfenteItemList = new List<Item>();
+
+    ItemData data;
+
+    System.Random rand = new System.Random((int)Time.time);
+    public void Init()
+    {
+        itemPrefab = (GameObject)Resources.Load("Prefabs/ItemPrefab");
+        if(itemPrefab != null)
+        {
+            Debug.Log("ItemPrefabロード成功");
+        }
+        data = (ItemData)Resources.Load("ItemDataTable");
+        if (data != null)
+        {
+            attackItemList = data.PowerList;
+            dfenteItemList = data.NormalList;
+            Debug.Log("Itemデータロード成功");
+        }
+        itemObj = GameObject.Instantiate(itemPrefab);
+        itemObj.SetActive(false);
+        TypeEventSystem.Instance.Register<PlayerGetItem>(e =>
+        {
+            if (!e.player.isHadItem)
+            {
+                GiveItem(e.player);
+                itemObj.SetActive(false);
+            }
+        }).UnregisterWhenGameObjectDestroyde(GameManager.Instance.gameObject);
+    }
+
+    public void SpawnItem()
+    {
+        //道具生成
+    }
+
+    private void GiveItem(IPlayer player)
+    {
+        Item giveItem;
+        if (!player.isHadSilk)
+        {
+            giveItem = attackItemList[rand.Next(0, attackItemList.Count)];
+        }
+        else
+        {
+            giveItem = dfenteItemList[rand.Next(0, dfenteItemList.Count)];
+        }
+        player.GetItem(giveItem);
+    }
+}

--- a/Assets/Script/System/ItemSystem/ItemSystem.cs.meta
+++ b/Assets/Script/System/ItemSystem/ItemSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4601f41e5251cac4887f5918e04e8b69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
实现道具系统，具体的道具待实现。
使用方法，具体的道具脚本继承自Item，并实现action函数，action函数里一般写对玩家状态的变更（修改移动速度之类的），将写好的脚本拖进资源文件夹的ItemDataTable中对应的list。两个list分别是进攻道具和防守道具。
道具生成规则待确定。
玩家抽象类按照IPlayer中的TPlayer抽象类修改